### PR TITLE
Add delay support and request signing to dispatcher and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ DISPATCHER_BACKEND_SECRET=your-secret
 
 The `DISPATCHER_BACKEND_URL` variable should point to the URL of the backend application. The `DISPATCHER_BACKEND_SECRET` variable is a shared secret that is used to sign the dispatched jobs. Make sure to keep this secret secure.
 
+Dispatcher signs the full request envelope (job, payload, queue, delay and batch data when present). This prevents queue/delay tampering in transit.
+
+For backward compatibility, backend verification still accepts legacy signatures that were generated only with `job + payload`.
+
 ### Generating a secret key
 The `dispatcher:generate-secret` command allows you to generate a secret key that is used to sign the dispatched jobs. You can use this command to generate a new secret key or replace an existing one.
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ You can then use the alias when dispatching the job:
 **Note:** Registering aliases is entirely optional and it only needs to be done in the backend server.
 
 ### Dispatching a job
-To dispatch a job from your application, use the dispatch method of the Dispatcher class. The method takes two parameters:
+To dispatch a job from your application, use the dispatch method of the Dispatcher class. The method takes up to four parameters:
 
 - `$job`: The fully qualified name of the job class to be dispatched.
 - `$payload`: An array of data to be passed to the job.
+- `$queue`: (optional) The queue name where the job should be dispatched.
+- `$delay`: (optional) Delay before dispatching the job. It can be an integer (seconds), a datetime string, or a `DateTimeInterface` / `DateInterval` instance.
 
 Here's an example:
 ```php
@@ -123,13 +125,24 @@ class ExampleController
     }
 }
 ```
+
+Dispatching with delay:
+
+```php
+<?php
+
+$dispatcher->dispatch(MyJob::class, ['foo' => 'bar'], queue: 'emails', delay: 120);
+// or
+$dispatcher->dispatch(MyJob::class, ['foo' => 'bar'], queue: 'emails', delay: now()->addMinutes(5));
+```
+
 The `dispatch` method will return the result of the dispatched job. You can use this result to track the status of the job or to perform further processing.
 
 ### Dispatching a batch of jobs
 
 To dispatch a batch of jobs, use the `batch` method of the `Dispatcher` class. The method takes three parameters:
 
-- `$jobs`: an array of `Assetplan\Dispatcher\Queue\Job` objects: each with the name of the target job and it's payload
+- `$jobs`: an array of `Assetplan\Dispatcher\Queue\Job` objects: each with the name of the target job, its payload and an optional delay.
 - `$queue`: the queue to which the jobs should be dispatched
 - `$shouldBatch`: whether the batch should be dispatched as a Laravel Queue Batch or simply dispatch all the jobs separately
 
@@ -148,7 +161,8 @@ class ExampleController
         $jobs = [
             new Job(
                 SendWelcomeEmail::class,
-                ['email'=>'user@example.com']
+                ['email'=>'user@example.com'],
+                delay: 300,
             ),
             new Job(
                 'App\Jobs\InviteToUserGroup',

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -4,11 +4,15 @@ namespace Assetplan\Dispatcher;
 
 use Assetplan\Dispatcher\Queue\Job;
 use Assetplan\Dispatcher\Support\Result;
+use DateInterval;
+use DateTimeInterface;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class Dispatcher
 {
@@ -25,8 +29,10 @@ class Dispatcher
         $this->queue = $queue;
     }
 
-    public function dispatch(string $job, array $payload = [], $queue = 'default'): Result
+    public function dispatch(string $job, array $payload = [], $queue = 'default', int|string|DateTimeInterface|DateInterval|null $delay = null): Result
     {
+        $serializedDelay = $this->serializeDelay($delay);
+
         $signature = $this->sign($job, $payload);
         $response = $this->http
             ->withHeaders(['Accept' => 'application/json'])
@@ -35,6 +41,7 @@ class Dispatcher
                 'payload' => $payload,
                 'signature' => $signature,
                 'queue' => $queue ?? 'default',
+                'delay' => $serializedDelay,
             ]);
 
         if ($response->failed()) {
@@ -50,7 +57,14 @@ class Dispatcher
 
     public function batch(array $jobs, string $queue = 'default', bool $shouldBatch = true): Result
     {
-        $jobs = collect($jobs)->filter(fn ($job) => $job instanceof Job);
+        $jobs = collect($jobs)
+            ->filter(fn ($job) => $job instanceof Job)
+            ->map(fn (Job $job) => [
+                'name' => $job->name,
+                'payload' => $job->payload,
+                'delay' => $this->serializeDelay($job->delay),
+            ])
+            ->values();
 
         $batchId = Str::uuid();
 
@@ -65,7 +79,7 @@ class Dispatcher
         $fields = [
             'job' => $batchId,
             'payload' => $payload,
-            'batch' => $jobs,
+            'batch' => $jobs->all(),
             'signature' => $signature,
             'queue' => $queue ?? 'default',
         ];
@@ -83,9 +97,15 @@ class Dispatcher
         return new Result($response['id'], $response);
     }
 
-    public function receive(string $job, array $payload = [], string $queue = 'default'): mixed
+    public function receive(string $job, array $payload = [], string $queue = 'default', int|string|DateTimeInterface|DateInterval|null $delay = null): mixed
     {
         $job = $this->makeJob($job, $payload);
+
+        $normalizedDelay = $this->normalizeDelay($delay);
+
+        if (! is_null($normalizedDelay)) {
+            return $this->queue->laterOn($queue, $normalizedDelay, $job);
+        }
 
         return $this->queue->pushOn($queue, $job);
     }
@@ -96,16 +116,33 @@ class Dispatcher
 
         foreach ($batch as $job) {
             $job = Job::fromJson($job);
-            $jobs[] = $this->makeJob($job->name, $job->payload);
+
+            $resolvedJob = $this->makeJob($job->name, $job->payload);
+            $delay = $this->normalizeDelay($job->delay);
+
+            if (! is_null($delay) && method_exists($resolvedJob, 'delay')) {
+                $resolvedJob->delay($delay);
+            }
+
+            $jobs[] = [
+                'job' => $resolvedJob,
+                'delay' => $delay,
+            ];
         }
+
         if ($shouldBatch) {
-            return Bus::batch($jobs)->onQueue($queue)->dispatch()->jsonSerialize();
+            return Bus::batch(array_map(fn (array $job) => $job['job'], $jobs))->onQueue($queue)->dispatch()->jsonSerialize();
         }
 
         $results = [];
 
         foreach ($jobs as $job) {
-            $results[] = ['id' => $this->queue->pushOn($queue, $job)];
+            if (! is_null($job['delay'])) {
+                $results[] = ['id' => $this->queue->laterOn($queue, $job['delay'], $job['job'])];
+                continue;
+            }
+
+            $results[] = ['id' => $this->queue->pushOn($queue, $job['job'])];
         }
 
         return $results;
@@ -133,5 +170,59 @@ class Dispatcher
     public function sign(string $job, array $payload = [])
     {
         return $this->hasher->make($job.json_encode($payload).config('dispatcher.secret'));
+    }
+
+    protected function serializeDelay(int|string|DateTimeInterface|DateInterval|null $delay): int|string|null
+    {
+        if (is_null($delay)) {
+            return null;
+        }
+
+        if ($delay instanceof DateInterval) {
+            return now()->add($delay)->toIso8601String();
+        }
+
+        if ($delay instanceof DateTimeInterface) {
+            return Carbon::instance($delay)->toIso8601String();
+        }
+
+        if (is_string($delay) && is_numeric($delay)) {
+            return (int) $delay;
+        }
+
+        return $delay;
+    }
+
+    protected function normalizeDelay(int|string|DateTimeInterface|DateInterval|null $delay): int|DateTimeInterface|null
+    {
+        if (is_null($delay)) {
+            return null;
+        }
+
+        if ($delay instanceof DateInterval) {
+            return now()->add($delay);
+        }
+
+        if ($delay instanceof DateTimeInterface) {
+            return $delay;
+        }
+
+        if (is_string($delay) && trim($delay) === '') {
+            return null;
+        }
+
+        if (is_string($delay) && is_numeric($delay)) {
+            return (int) $delay;
+        }
+
+        if (is_string($delay)) {
+            return Carbon::parse($delay);
+        }
+
+        if (is_int($delay)) {
+            return $delay;
+        }
+
+        throw new InvalidArgumentException('Invalid delay value.');
     }
 }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -33,16 +33,19 @@ class Dispatcher
     {
         $serializedDelay = $this->serializeDelay($delay);
 
-        $signature = $this->sign($job, $payload);
+        $fields = [
+            'job' => $job,
+            'payload' => $payload,
+            'queue' => $queue ?? 'default',
+            'delay' => $serializedDelay,
+        ];
+
+        $signature = $this->signRequest($fields);
         $response = $this->http
             ->withHeaders(['Accept' => 'application/json'])
-            ->post(config('dispatcher.url').'/dispatch', [
-                'job' => $job,
-                'payload' => $payload,
+            ->post(config('dispatcher.url').'/dispatch', array_merge($fields, [
                 'signature' => $signature,
-                'queue' => $queue ?? 'default',
-                'delay' => $serializedDelay,
-            ]);
+            ]));
 
         if ($response->failed()) {
             $response = ($response->json() ?? ['reason' => $response->reason()]);
@@ -75,14 +78,15 @@ class Dispatcher
             'createdAt' => now(),
         ];
 
-        $signature = $this->sign($batchId, $payload);
         $fields = [
             'job' => $batchId,
             'payload' => $payload,
             'batch' => $jobs->all(),
-            'signature' => $signature,
             'queue' => $queue ?? 'default',
         ];
+
+        $signature = $this->signRequest($fields);
+        $fields['signature'] = $signature;
 
         $response = $this->http
             ->withHeaders(['Accept' => 'application/json'])
@@ -170,6 +174,58 @@ class Dispatcher
     public function sign(string $job, array $payload = [])
     {
         return $this->hasher->make($job.json_encode($payload).config('dispatcher.secret'));
+    }
+
+    public function signRequest(array $requestData = []): string
+    {
+        $normalized = $this->normalizeRequestData($requestData);
+
+        return $this->hasher->make(json_encode($normalized).config('dispatcher.secret'));
+    }
+
+    public function verifyRequest(array $requestData = [], string $signature = ''): bool
+    {
+        try {
+            $normalized = $this->normalizeRequestData($requestData);
+
+            if ($this->hasher->check(json_encode($normalized).config('dispatcher.secret'), $signature)) {
+                return true;
+            }
+
+            return $this->verify(
+                $requestData['job'] ?? '',
+                $requestData['payload'] ?? [],
+                $signature,
+            );
+        } catch (\RuntimeException $e) {
+            return false;
+        }
+    }
+
+    protected function normalizeRequestData(array $requestData): array
+    {
+        $data = [
+            'job' => $requestData['job'] ?? null,
+            'payload' => $requestData['payload'] ?? [],
+            'queue' => $requestData['queue'] ?? 'default',
+            'delay' => $requestData['delay'] ?? null,
+            'batch' => $requestData['batch'] ?? null,
+        ];
+
+        return $this->sortArrayRecursively($data);
+    }
+
+    protected function sortArrayRecursively(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = $this->sortArrayRecursively($value);
+            }
+        }
+
+        ksort($data);
+
+        return $data;
     }
 
     protected function serializeDelay(int|string|DateTimeInterface|DateInterval|null $delay): int|string|null

--- a/src/Http/Controllers/DispatchBatchController.php
+++ b/src/Http/Controllers/DispatchBatchController.php
@@ -16,6 +16,7 @@ class DispatchBatchController
             'signature' => 'required',
             'payload.shouldBatch' => 'required|boolean',
             'batch.*.name' => ['required', new IsIlluminateJob],
+            'batch.*.delay' => 'sometimes',
         ]);
 
         $queue = 'default';

--- a/src/Http/Controllers/DispatchJobController.php
+++ b/src/Http/Controllers/DispatchJobController.php
@@ -14,6 +14,7 @@ class DispatchJobController
             'job' => ['required', new IsIlluminateJob],
             'payload' => 'required',
             'queue' => 'sometimes',
+            'delay' => 'sometimes',
             'signature' => 'required',
         ]);
 
@@ -23,6 +24,6 @@ class DispatchJobController
             $queue = $request->input('queue');
         }
 
-        return response()->json(['id' => $dispatcher->receive($request->job, $request->payload, $queue)]);
+        return response()->json(['id' => $dispatcher->receive($request->job, $request->payload, $queue, $request->input('delay'))]);
     }
 }

--- a/src/Http/Middleware/DispatcherMiddleware.php
+++ b/src/Http/Middleware/DispatcherMiddleware.php
@@ -14,7 +14,13 @@ class DispatcherMiddleware
             abort(400, 'Only JSON requests are accepted');
         }
 
-        if (! DispatcherFacade::verify($request->job, $request->payload, $request->signature)) {
+        if (! DispatcherFacade::verifyRequest([
+            'job' => $request->input('job'),
+            'payload' => $request->input('payload', []),
+            'queue' => $request->input('queue', 'default'),
+            'delay' => $request->input('delay'),
+            'batch' => $request->input('batch'),
+        ], $request->input('signature', ''))) {
             abort(403, 'Invalid signature');
         }
 

--- a/src/Queue/Job.php
+++ b/src/Queue/Job.php
@@ -2,16 +2,22 @@
 
 namespace Assetplan\Dispatcher\Queue;
 
+use DateInterval;
+use DateTimeInterface;
+
 class Job
 {
     public string $name;
 
     public array $payload;
 
-    public function __construct(string $name, array $payload = [])
+    public int|string|DateTimeInterface|DateInterval|null $delay;
+
+    public function __construct(string $name, array $payload = [], int|string|DateTimeInterface|DateInterval|null $delay = null)
     {
         $this->name = $name;
         $this->payload = $payload;
+        $this->delay = $delay;
     }
 
     public static function fromJson(string|array $job): self
@@ -25,6 +31,6 @@ class Job
 
     public static function fromArray(array $job): self
     {
-        return new static($job['name'], $job['payload']);
+        return new static($job['name'], $job['payload'] ?? [], $job['delay'] ?? null);
     }
 }

--- a/tests/DispatcherDelayTest.php
+++ b/tests/DispatcherDelayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Assetplan\Dispatcher\Tests;
+
+use Assetplan\Dispatcher\Dispatcher;
+use Assetplan\Dispatcher\Queue\Job;
+use Assetplan\Dispatcher\Tests\Mocks\DummyJob;
+use Assetplan\Dispatcher\Tests\Mocks\HttpMock;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Hashing\BcryptHasher;
+
+class DispatcherDelayTest extends TestCase
+{
+    public function testDispatchSendsDelay(): void
+    {
+        $http = new HttpMock();
+        $queue = $this->createMock(Queue::class);
+
+        $dispatcher = new Dispatcher(new BcryptHasher(), $http, $queue);
+
+        $result = $dispatcher->dispatch('test-job', ['foo' => 'bar'], 'default', 120);
+
+        $this->assertFalse($result->failed());
+        $this->assertSame(120, $http->lastPostData['delay']);
+    }
+
+    public function testReceiveUsesLaterOnWhenDelayExists(): void
+    {
+        $http = new HttpMock();
+        $queue = $this->createMock(Queue::class);
+
+        $queue->expects($this->once())
+            ->method('laterOn')
+            ->with('emails', 120, $this->isInstanceOf(DummyJob::class))
+            ->willReturn('queue-id-1');
+
+        $queue->expects($this->never())->method('pushOn');
+
+        $dispatcher = new Dispatcher(new BcryptHasher(), $http, $queue);
+
+        $result = $dispatcher->receive(DummyJob::class, ['foo' => 'bar'], 'emails', 120);
+
+        $this->assertSame('queue-id-1', $result);
+    }
+
+    public function testReceiveBatchUsesDelayPerJobWhenNotBatching(): void
+    {
+        $http = new HttpMock();
+        $queue = $this->createMock(Queue::class);
+
+        $queue->expects($this->once())
+            ->method('laterOn')
+            ->with('emails', 300, $this->isInstanceOf(DummyJob::class))
+            ->willReturn('queue-id-delayed');
+
+        $queue->expects($this->once())
+            ->method('pushOn')
+            ->with('emails', $this->isInstanceOf(DummyJob::class))
+            ->willReturn('queue-id-immediate');
+
+        $dispatcher = new Dispatcher(new BcryptHasher(), $http, $queue);
+
+        $results = $dispatcher->receiveBatch([
+            new Job(DummyJob::class, ['foo' => 'first'], 300),
+            new Job(DummyJob::class, ['foo' => 'second']),
+        ], 'emails', false);
+
+        $this->assertSame([
+            ['id' => 'queue-id-delayed'],
+            ['id' => 'queue-id-immediate'],
+        ], $results);
+    }
+}

--- a/tests/Mocks/DummyJob.php
+++ b/tests/Mocks/DummyJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Assetplan\Dispatcher\Tests\Mocks;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyJob implements ShouldQueue
+{
+    use Queueable;
+
+    public ?string $foo;
+
+    public function __construct(?string $foo = null)
+    {
+        $this->foo = $foo;
+    }
+
+    public function handle(): void {}
+}

--- a/tests/Mocks/HttpMock.php
+++ b/tests/Mocks/HttpMock.php
@@ -6,6 +6,12 @@ use Illuminate\Http\Client\PendingRequest;
 
 class HttpMock extends PendingRequest
 {
+    public array $lastPostData = [];
+
+    public bool $shouldFail = false;
+
+    public array $response = ['id' => 'mock-id'];
+
     public function withHeaders(array $headers)
     {
         return $this;
@@ -13,17 +19,22 @@ class HttpMock extends PendingRequest
 
     public function post(string $url, $data = [])
     {
-        // return new Response([]);
+        $this->lastPostData = $data;
+
         return $this;
     }
 
     public function json()
     {
-        return [];
+        return $this->response;
     }
 
     public function failed($shouldFail = false)
     {
-        return ! $shouldFail;
+        if ($shouldFail) {
+            return true;
+        }
+
+        return $this->shouldFail;
     }
 }

--- a/tests/SignatureTest.php
+++ b/tests/SignatureTest.php
@@ -52,4 +52,63 @@ class SignatureTest extends TestCase
 
         $this->assertFalse($verified);
     }
+
+    public function testRequestSignature()
+    {
+        $dispatcher = app()->make('dispatcher');
+
+        $request = [
+            'job' => 'App\\Jobs\\SyncSomething',
+            'payload' => ['foo' => 'bar'],
+            'queue' => 'emails',
+            'delay' => 120,
+        ];
+
+        $signature = $dispatcher->signRequest($request);
+
+        $verified = $dispatcher->verifyRequest($request, $signature);
+
+        $this->assertTrue($verified);
+    }
+
+    public function testRequestSignatureFailsWhenQueueChanges()
+    {
+        $dispatcher = app()->make('dispatcher');
+
+        $request = [
+            'job' => 'App\\Jobs\\SyncSomething',
+            'payload' => ['foo' => 'bar'],
+            'queue' => 'emails',
+            'delay' => 120,
+        ];
+
+        $signature = $dispatcher->signRequest($request);
+
+        $request['queue'] = 'critical';
+
+        $verified = $dispatcher->verifyRequest($request, $signature);
+
+        $this->assertFalse($verified);
+    }
+
+    public function testRequestVerificationSupportsLegacySignature()
+    {
+        $dispatcher = app()->make('dispatcher');
+
+        $payload = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ];
+
+        $legacySignature = $dispatcher->sign('test', $payload);
+
+        $verified = $dispatcher->verifyRequest([
+            'job' => 'test',
+            'payload' => $payload,
+            'queue' => 'emails',
+            'delay' => 180,
+        ], $legacySignature);
+
+        $this->assertTrue($verified);
+    }
 }


### PR DESCRIPTION
This pull request introduces support for per-job delay and queue parameters throughout the dispatcher system, enhances request signing and verification for better security, and updates documentation and tests accordingly. The most important changes are grouped as follows:

**Feature: Per-job Delay and Queue Support**
- Added support for specifying a `delay` (as integer, string, `DateTimeInterface`, or `DateInterval`) for individual jobs and batches in the `Dispatcher` and `Job` classes. This allows jobs to be scheduled for future execution and ensures delays are respected both when dispatching and receiving jobs. (`src/Dispatcher.php`, `src/Queue/Job.php`, `README.md`) [[1]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0L28-R48) [[2]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0L53-R70) [[3]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0L86-R113) [[4]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0L99-R149) [[5]](diffhunk://#diff-0f4cfc21714aed648ffed3e5ff406253ac81c94c0f649590e23064185a37a7ceR5-R20) [[6]](diffhunk://#diff-0f4cfc21714aed648ffed3e5ff406253ac81c94c0f649590e23064185a37a7ceL28-R34) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R110) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R132-R149) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R169)

**Security: Improved Request Signing and Verification**
- Enhanced the signing process to include the full request envelope (`job`, `payload`, `queue`, `delay`, and `batch`), preventing tampering with queue or delay parameters in transit. The backend now verifies signatures using all these fields but maintains backward compatibility with legacy signatures. (`src/Dispatcher.php`, `src/Http/Middleware/DispatcherMiddleware.php`, `README.md`) [[1]](diffhunk://#diff-85f8c2cf9079b12b6f472456fafba60513af3c08efecccc070133e54b283eac0R178-R283) [[2]](diffhunk://#diff-675f9f00371401c591e0bac9294927c0429d1b4f53271ac0c17ff415b8c85d2bL17-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R35)

**API and Validation Updates**
- Updated controller validation rules and logic to accept and process the new `delay` parameter for both single and batch job dispatch endpoints. (`src/Http/Controllers/DispatchJobController.php`, `src/Http/Controllers/DispatchBatchController.php`) [[1]](diffhunk://#diff-6d5bb9563d8f4fa6cfd69a4ddf86822c703baea4db2e64765fd0eb6c430461b0R17) [[2]](diffhunk://#diff-6d5bb9563d8f4fa6cfd69a4ddf86822c703baea4db2e64765fd0eb6c430461b0L26-R27) [[3]](diffhunk://#diff-0dbf5625d8f4783caa0d878a3cf017e3789b7ae6c205d912cc7717f6b8528bafR19)

**Documentation Improvements**
- Expanded the `README.md` to document the new delay and queue parameters, provide usage examples, and clarify the updated signature mechanism. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R110) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R132-R149) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R169)

**Testing Enhancements**
- Added comprehensive tests for delay functionality in dispatching and receiving jobs, and for the new signature verification logic, including legacy support and tampering scenarios. Mock classes were updated or added as needed. (`tests/DispatcherDelayTest.php`, `tests/SignatureTest.php`, `tests/Mocks/DummyJob.php`, `tests/Mocks/HttpMock.php`) [[1]](diffhunk://#diff-1174e793a8ede3b8694a8d54395195479819df6c01b75063d68a50142057ca17R1-R73) [[2]](diffhunk://#diff-0f3d0e48225c9ac4c7ea3a821141d9ef652266bd91bb8addcd23598687786a03R55-R113) [[3]](diffhunk://#diff-4dbd0a1578260167d2c8bc43619918e511e1f7ba5a6161cdc372f2136a439530R1-R20) [[4]](diffhunk://#diff-d6eafaab4c3eb64c78fa4ce44676fcf4bc8b1936413cca5bdbd13a562d7d0535R9-R38)